### PR TITLE
Feature/spring cloud stream

### DIFF
--- a/broker/build.gradle
+++ b/broker/build.gradle
@@ -5,6 +5,8 @@ dependencies {
     compile group: 'org.springframework.boot', name: 'spring-boot-starter-actuator'
     //compile group: 'org.springframework.boot', name: 'spring-boot-starter-data-jpa'
     compile group: 'org.springframework.boot', name: 'spring-boot-starter-webflux'
+    compile group: 'org.springframework.cloud', name: 'spring-cloud-stream'
+    compile group: 'org.springframework.cloud', name: 'spring-cloud-starter-stream-rabbit'
 
     compile group: 'io.netty', name: 'netty-common'
     compile group: 'io.netty', name: 'netty-buffer'

--- a/broker/src/main/java/io/moquette/SpringBootServer.java
+++ b/broker/src/main/java/io/moquette/SpringBootServer.java
@@ -1,15 +1,18 @@
 package io.moquette;
 
 import java.io.IOException;
+import java.util.ArrayList;
 import java.util.List;
 
 import io.moquette.interception.InterceptHandler;
+import io.moquette.interception.SpringCloudInterceptor;
 import io.moquette.server.SpringMqttServer;
 import io.moquette.server.config.SpringConfig;
 import io.moquette.server.netty.NettyAcceptor;
 import io.moquette.spi.impl.ProtocolProcessorBootstrapper;
 import io.moquette.spi.security.IAuthenticator;
 import io.moquette.spi.security.IAuthorizator;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.CommandLineRunner;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
@@ -22,6 +25,8 @@ public class SpringBootServer {
 
         SpringApplication.run(SpringBootServer.class, args);
     }
+    @Autowired
+    private SpringCloudInterceptor interceptor;
 
     @Bean
     CommandLineRunner commandLineRunner(SpringConfig config, IAuthenticator authenticator, IAuthorizator authorizator) {
@@ -29,11 +34,16 @@ public class SpringBootServer {
             ProtocolProcessorBootstrapper protocolProcessorBootstrapper = new ProtocolProcessorBootstrapper();
             NettyAcceptor acceptor = new NettyAcceptor();
             final SpringMqttServer server = new SpringMqttServer(protocolProcessorBootstrapper, acceptor);
-            List<InterceptHandler> handlers = null;
+            List<InterceptHandler> handlers = new ArrayList<>();
+            handlers.add(interceptor);
             server.startServer(config, handlers, null, authenticator, authorizator);
             System.out.println("Server started, version 0.11-SNAPSHOT");
             //Bind  a shutdown hook
             Runtime.getRuntime().addShutdownHook(new Thread(server::stopServer));
         };
+    }
+
+    public void setInterceptor(final SpringCloudInterceptor interceptor) {
+        this.interceptor = interceptor;
     }
 }

--- a/broker/src/main/java/io/moquette/SpringBootServer.java
+++ b/broker/src/main/java/io/moquette/SpringBootServer.java
@@ -35,6 +35,7 @@ public class SpringBootServer {
             NettyAcceptor acceptor = new NettyAcceptor();
             final SpringMqttServer server = new SpringMqttServer(protocolProcessorBootstrapper, acceptor);
             List<InterceptHandler> handlers = new ArrayList<>();
+            interceptor.setPublisher(server::internalPublish);
             handlers.add(interceptor);
             server.startServer(config, handlers, null, authenticator, authorizator);
             System.out.println("Server started, version 0.11-SNAPSHOT");

--- a/broker/src/main/java/io/moquette/interception/SpringCloudInterceptor.java
+++ b/broker/src/main/java/io/moquette/interception/SpringCloudInterceptor.java
@@ -1,0 +1,45 @@
+package io.moquette.interception;
+
+import io.moquette.interception.messages.InterceptPublishMessage;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.cloud.stream.annotation.EnableBinding;
+import org.springframework.cloud.stream.annotation.StreamListener;
+import org.springframework.cloud.stream.messaging.Processor;
+import org.springframework.messaging.Message;
+import org.springframework.messaging.MessageChannel;
+import org.springframework.messaging.handler.annotation.Payload;
+import org.springframework.messaging.support.MessageBuilder;
+
+import java.nio.charset.Charset;
+
+/**
+ * @author Shalbanov, Kostiantyn (kostiantyn.shalbanov@intecsoft.de)
+ */
+@EnableBinding(Processor.class)
+public class SpringCloudInterceptor extends AbstractInterceptHandler {
+
+    private MessageChannel output;
+
+    @Override
+    public String getID() {
+        return this.getClass().getName();
+    }
+
+    @Autowired
+    public SpringCloudInterceptor (MessageChannel output) {
+        this.output = output;
+    }
+
+    @Override
+    public void onPublish(final InterceptPublishMessage msg) {
+        final String msgTxt = msg.getPayload().toString(Charset.defaultCharset());
+        System.out.println(msgTxt);
+        final Message<String> amqpMsg = MessageBuilder.withPayload(msgTxt).build();
+        output.send(amqpMsg);
+    }
+
+    @StreamListener(Processor.INPUT)
+    public void receive(String msg) {
+        System.out.println("Received message is: " + msg);
+    }
+}

--- a/broker/src/main/java/io/moquette/interception/SpringCloudInterceptor.java
+++ b/broker/src/main/java/io/moquette/interception/SpringCloudInterceptor.java
@@ -1,16 +1,28 @@
 package io.moquette.interception;
 
 import io.moquette.interception.messages.InterceptPublishMessage;
+import io.moquette.server.InternalPublisher;
+import io.netty.buffer.ByteBuf;
+import io.netty.buffer.Unpooled;
+import io.netty.handler.codec.mqtt.MqttFixedHeader;
+import io.netty.handler.codec.mqtt.MqttMessageType;
+import io.netty.handler.codec.mqtt.MqttPublishMessage;
+import io.netty.handler.codec.mqtt.MqttPublishVariableHeader;
+import io.netty.handler.codec.mqtt.MqttQoS;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.cloud.stream.annotation.EnableBinding;
 import org.springframework.cloud.stream.annotation.StreamListener;
 import org.springframework.cloud.stream.messaging.Processor;
 import org.springframework.messaging.Message;
 import org.springframework.messaging.MessageChannel;
+import org.springframework.messaging.handler.annotation.Headers;
 import org.springframework.messaging.handler.annotation.Payload;
 import org.springframework.messaging.support.MessageBuilder;
 
 import java.nio.charset.Charset;
+import java.util.Map;
 
 /**
  * @author Shalbanov, Kostiantyn (kostiantyn.shalbanov@intecsoft.de)
@@ -18,7 +30,10 @@ import java.nio.charset.Charset;
 @EnableBinding(Processor.class)
 public class SpringCloudInterceptor extends AbstractInterceptHandler {
 
+    private static Logger logger = LoggerFactory.getLogger(SpringCloudMsg.class);
+
     private MessageChannel output;
+    private InternalPublisher publisher;
 
     @Override
     public String getID() {
@@ -32,14 +47,39 @@ public class SpringCloudInterceptor extends AbstractInterceptHandler {
 
     @Override
     public void onPublish(final InterceptPublishMessage msg) {
-        final String msgTxt = msg.getPayload().toString(Charset.defaultCharset());
-        System.out.println(msgTxt);
-        final Message<String> amqpMsg = MessageBuilder.withPayload(msgTxt).build();
-        output.send(amqpMsg);
+        final ByteBuf payload = msg.getPayload();
+        if (null != payload) {
+            logger.debug("Publishing following message in the cloud: {}", payload.toString(Charset.defaultCharset()));
+        } else {
+            logger.debug("Publishing 'null' message in the cloud.");
+        }
+        final Message<SpringCloudMsg> externalMsg = MessageBuilder
+            .withPayload(new SpringCloudMsg(msg))
+            .build();
+        output.send(externalMsg);
     }
 
     @StreamListener(Processor.INPUT)
-    public void receive(String msg) {
-        System.out.println("Received message is: " + msg);
+    public void receive(@Payload SpringCloudMsg msg, @Headers Map<String, String> headers) {
+
+        final String msgText = new String(msg.getPayload());
+        logger.debug("Following message is received from the cloud: {}", msgText);
+        if (null == publisher) {
+            logger.error("No Publisher defined. Message can't be sent.");
+            return;
+        }
+
+        MqttQoS qos = MqttQoS.valueOf(msg.getQos());
+        MqttFixedHeader fixedHeader = new MqttFixedHeader(MqttMessageType.PUBLISH, false, qos, false, 0);
+        MqttPublishVariableHeader varHeader = new MqttPublishVariableHeader(msg.getTopic(), 0);
+        final ByteBuf payload = Unpooled.wrappedBuffer(msg.getPayload());
+        MqttPublishMessage publishMessage = new MqttPublishMessage(fixedHeader, varHeader, payload);
+
+        logger.debug("From the cloud received message is going to be published: {}", msgText);
+        publisher.publish(publishMessage, msg.getClientId());
+    }
+
+    public void setPublisher(final InternalPublisher publisher) {
+        this.publisher = publisher;
     }
 }

--- a/broker/src/main/java/io/moquette/interception/SpringCloudMsg.java
+++ b/broker/src/main/java/io/moquette/interception/SpringCloudMsg.java
@@ -1,0 +1,58 @@
+package io.moquette.interception;
+
+import io.moquette.interception.messages.InterceptPublishMessage;
+
+import java.io.Serializable;
+
+import static io.moquette.spi.impl.Utils.readBytesAndRewind;
+
+/**
+ * @author Shalbanov, Kostiantyn (kostiantyn.shalbanov@intecsoft.de)
+ */
+public class SpringCloudMsg implements Serializable {
+    private String clientId;
+    private int qos;
+    private byte[] payload;
+    private String topic;
+
+    public SpringCloudMsg(){}
+
+    public SpringCloudMsg(InterceptPublishMessage msg) {
+        this.clientId = msg.getClientID();
+        this.topic = msg.getTopicName();
+        this.qos = msg.getQos().value();
+        this.payload = readBytesAndRewind(msg.getPayload());
+    }
+
+    public String getClientId() {
+        return clientId;
+    }
+
+    public int getQos() {
+        return qos;
+    }
+
+    public byte[] getPayload() {
+        return payload;
+    }
+
+    public String getTopic() {
+        return topic;
+    }
+
+    public void setClientId(final String clientId) {
+        this.clientId = clientId;
+    }
+
+    public void setQos(final int qos) {
+        this.qos = qos;
+    }
+
+    public void setPayload(final byte[] payload) {
+        this.payload = payload;
+    }
+
+    public void setTopic(final String topic) {
+        this.topic = topic;
+    }
+}

--- a/broker/src/main/java/io/moquette/server/InternalPublisher.java
+++ b/broker/src/main/java/io/moquette/server/InternalPublisher.java
@@ -1,0 +1,10 @@
+package io.moquette.server;
+
+import io.netty.handler.codec.mqtt.MqttPublishMessage;
+
+/**
+ * @author Shalbanov, Kostiantyn (kostiantyn.shalbanov@intecsoft.de)
+ */
+public interface InternalPublisher {
+    void publish(MqttPublishMessage msg, final String clientId);
+}

--- a/broker/src/main/resources/application.yml
+++ b/broker/src/main/resources/application.yml
@@ -1,0 +1,13 @@
+spring:
+  rabbitmq:
+    host: 10.66.0.2
+    port: 5672
+    username: guest
+    password: guest
+  cloud:
+    stream:
+      bindings:
+        output:
+          destination: test
+        input:
+          destination: test

--- a/broker/src/main/resources/application.yml
+++ b/broker/src/main/resources/application.yml
@@ -1,6 +1,6 @@
 spring:
   rabbitmq:
-    host: 10.66.0.2
+    host: 10.66.0.1
     port: 5672
     username: guest
     password: guest

--- a/build.gradle
+++ b/build.gradle
@@ -29,6 +29,7 @@ subprojects {
     maven { url "http://repo.maven.apache.org/maven2" }
     maven { url "https://repo.spring.io/snapshot" }
     maven { url "https://repo.spring.io/milestone" }
+    maven { url "https://repo.spring.io/libs-milestone" }
     jcenter()
   }
 

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
-#Thu Aug 10 18:13:58 CEST 2017
+#Wed Mar 07 14:24:39 CET 2018
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-3.3-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-3.3-all.zip


### PR DESCRIPTION
Spring Cloud Stream is used as an abstraction layer between moquette and RabbitMQ. Because of that, RabbitMQ could be easily substituted. Cloud Stream API is referenced only in the SpringCloudInterceptor.

![mqtt-broker-springcloud](https://user-images.githubusercontent.com/6057480/37165725-9e6f8b02-22fd-11e8-8366-963fde10858c.png)
 